### PR TITLE
Fix date formatting in student registration

### DIFF
--- a/src/components/StudentRegistrationForm.tsx
+++ b/src/components/StudentRegistrationForm.tsx
@@ -8,6 +8,7 @@ import { StepThree } from "./registration-steps/StepThree";
 import { SuccessMessage } from "./registration-steps/SuccessMessage";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import { format } from "date-fns";
 
 export interface StudentFormData {
   // Step 1 - Demographics
@@ -106,7 +107,7 @@ export const StudentRegistrationForm = () => {
           first_name: formData.firstName,
           last_name: formData.lastName,
           gender: formData.gender,
-          date_of_birth: formData.dateOfBirth?.toISOString().split('T')[0],
+          date_of_birth: formData.dateOfBirth ? format(formData.dateOfBirth, 'yyyy-MM-dd') : null,
           email: formData.email,
           mobile: formData.mobile,
           profile_image_url: profileImageUrl,

--- a/src/components/registration-steps/StepOne.tsx
+++ b/src/components/registration-steps/StepOne.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { differenceInYears } from "date-fns";
+import { differenceInYears, format } from "date-fns";
 import { StudentFormData } from "../StudentRegistrationForm";
 import { useToast } from "@/hooks/use-toast";
 
@@ -119,12 +119,12 @@ export const StepOne = ({ formData, updateFormData, onNext }: StepOneProps) => {
         <Input
           id="dateOfBirth"
           type="date"
-          value={formData.dateOfBirth ? formData.dateOfBirth.toISOString().split('T')[0] : ''}
+          value={formData.dateOfBirth ? format(formData.dateOfBirth, 'yyyy-MM-dd') : ''}
           onChange={(e) => {
             const date = e.target.value ? new Date(e.target.value) : undefined;
             updateFormData({ dateOfBirth: date });
           }}
-          max={new Date().toISOString().split('T')[0]}
+          max={format(new Date(), 'yyyy-MM-dd')}
           className="w-full"
         />
       </div>


### PR DESCRIPTION
## Summary
- fix timezone-safe date formatting in registration steps
- use consistent `yyyy-MM-dd` formatting when saving to Supabase

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685286da08048324ad5500162e365552